### PR TITLE
Fix Weathermap integration dependencies

### DIFF
--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -85,7 +85,7 @@ jobs:
       run: sudo apt-get update
     
     - name: Install System Dependencies
-      run: sudo apt-get install -y apache2 snmp snmpd rrdtool fping libapache2-mod-php${{ matrix.php }}
+      run: sudo apt-get install -y apache2 snmp snmpd rrdtool fping
     
     - name: Start SNMPD Agent and Test
       run: |


### PR DESCRIPTION
## Summary

- remove unavailable Ubuntu-versioned Apache PHP packages from the integration matrix

The PHP runtime is supplied by `setup-php`; the integration suite does not require a versioned Apache module.

## Validation

- `git diff --check`
- workflow YAML parsed successfully

Kept separate from #238 so the PHP 8 number-formatting fix remains focused.