### PR TITLE
fix: Repair three fatal defects in the cacti, wmdata and rrd datasources

### DIFF
--- a/lib/datasources/WeatherMapDataSource_cacti.php
+++ b/lib/datasources/WeatherMapDataSource_cacti.php
@@ -44,11 +44,7 @@ class WeatherMapDataSource_cacti extends WeatherMapDataSource {
 			$data_time = $result['last_time'];
 		}
 
-		wm_debug(sprintf("cacti ReadData: Returning (%s, %s, %s)\n",
-			string_or_null($data[IN]),
-			string_or_null($data[OUT]),
-			$data_time
-		));
+		wm_debug('cacti ReadData: Returning (' . ($data[IN] === null ? 'NULL' : $data[IN]) . ',' . ($data[OUT] === null ? 'NULL' : $data[OUT]) . ",$data_time)");
 
 		return ([
 			$data[IN],

--- a/lib/datasources/WeatherMapDataSource_rrd.php
+++ b/lib/datasources/WeatherMapDataSource_rrd.php
@@ -90,6 +90,27 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 		return (false);
 	}
 
+	/**
+	 * Decide whether an rrd_options string is safe to append to the RRDTool
+	 * command line.
+	 *
+	 * Each option token is passed through cacti_escapeshellarg() before it
+	 * reaches the shell, so this is a second line of defence rather than the
+	 * only one.  A quote or backslash is rejected because it turns one intended
+	 * flag into several arguments.
+	 *
+	 * strpbrk() replaces the character class this guard used to carry.  Written
+	 * as '/["\'\\]/' in single quotes, that pattern reached PCRE as an
+	 * unterminated class, so preg_match() returned false and the guard never
+	 * fired for the whole life of the check.
+	 *
+	 * @param  string|null $options rrd_options as given in the map config
+	 * @return bool        true when the value holds no quote and no backslash
+	 */
+	function wmrrd_options_are_safe($options) {
+		return strpbrk((string) $options, "\"'\\") === false;
+	}
+
 	function Recognise($targetstring) {
 		if (preg_match('/^(.*\.rrd):([\-a-zA-Z0-9_]+):([\-a-zA-Z0-9_]+)$/', $targetstring, $matches)) {
 			return true;
@@ -317,7 +338,7 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 		}
 
 		if ($extra_options !== '' && $extra_options !== null) {
-			if (preg_match('/["\'\\]/', (string) $extra_options)) {
+			if (!$this->wmrrd_options_are_safe($extra_options)) {
 				$msg = 'RRD ReadData: rrd_options contains quote or backslash characters and was skipped to prevent argument corruption. Use only space-separated single-token flags. [WMRRD04]';
 				wm_warn($msg);
 				cacti_log('WEATHERMAP: ' . $msg, false, 'POLLER', POLLER_VERBOSITY_LOW);
@@ -427,7 +448,7 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 		}
 
 		if ($extra_options !== '' && $extra_options !== null) {
-			if (preg_match('/["\'\\]/', (string) $extra_options)) {
+			if (!$this->wmrrd_options_are_safe($extra_options)) {
 				$msg = 'RRD ReadData: rrd_options contains quote or backslash characters and was skipped to prevent argument corruption. Use only space-separated single-token flags. [WMRRD04]';
 				wm_warn($msg);
 				cacti_log('WEATHERMAP: ' . $msg, false, 'POLLER', POLLER_VERBOSITY_LOW);

--- a/lib/datasources/WeatherMapDataSource_wmdata.php
+++ b/lib/datasources/WeatherMapDataSource_wmdata.php
@@ -58,33 +58,38 @@ class WeatherMapDataSource_wmdata extends WeatherMapDataSource {
 		$data_time = 0;
 		$itemname  = $item->name;
 
-		$matches = 0;
+		$matches  = [];
+		$datafile = '';
+		$dataname = '';
 
-		if (preg_match('/^wmdata:([^:]*):(.*)', trim($targetstring), $matches)) {
+		if (preg_match('/^wmdata:([^:]*):(.*)$/', trim($targetstring), $matches)) {
 			$datafile = trim($matches[1]);
 			$dataname = trim($matches[2]);
+		} else {
+			wm_warn("WMData ReadData: Couldn't parse target ($targetstring). [WMWMDATA04]");
 		}
 
-		if (file_exists($datafile)) {
-			$fd = fopen($targetstring, 'r');
+		if ($datafile !== '' && file_exists($datafile)) {
+			$fd = fopen($datafile, 'r');
 
-			if ($fd) {
+			if ($fd !== false) {
 				$found = false;
 
-				while (!feof($fd)) {
-					$buffer = fgets($fd, 4096);
+				while (($buffer = fgets($fd, 4096)) !== false) {
 					// strip out any Windows line-endings that have gotten in here
 					$buffer = str_replace("\r", '', $buffer);
 
-					$fields = explode("\t",$buffer);
+					$fields = explode("\t", rtrim($buffer, "\n"));
 
-					if ($fields[0] == $dataname) {
+					if (isset($fields[2]) && $fields[0] == $dataname) {
 						$data[IN]  = $fields[1];
 						$data[OUT] = $fields[2];
 
 						$found = true;
 					}
 				}
+
+				fclose($fd);
 
 				if ($found === true) {
 					$stats     = stat($datafile);
@@ -99,13 +104,7 @@ class WeatherMapDataSource_wmdata extends WeatherMapDataSource {
 			wm_warn("WMData ReadData: $datafile doesn't exist [WMWMDATA01]");
 		}
 
-		wm_debug(
-			sprintf('WMData ReadData: Returning (%s, %s, %s)',
-				string_or_null($data[IN]),
-				string_or_null($data[OUT]),
-				$data_time
-			)
-		);
+		wm_debug('WMData ReadData: Returning (' . ($data[IN] === null ? 'NULL' : $data[IN]) . ',' . ($data[OUT] === null ? 'NULL' : $data[OUT]) . ",$data_time)");
 
 		return (
 			[

--- a/tests/Helpers/DataSourceHarness.php
+++ b/tests/Helpers/DataSourceHarness.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Minimum environment needed to load and drive a datasource class.
+ *
+ * The datasource files are the only part of the plugin these tests exercise, so
+ * the IN/OUT indices and the WeatherMapDataSource base are declared here rather
+ * than pulling in the 4,500-line WeatherMap.class.php and its Cacti bindings.
+ * wm_debug() and wm_warn() come from the real WeatherMap.functions.php: that
+ * file declares them unconditionally, so a local stub would collide with any
+ * other test that loads it.
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once dirname(__DIR__, 2) . '/lib/WeatherMap.functions.php';
+
+if (!defined('IN')) {
+	define('IN', 0);
+}
+
+if (!defined('OUT')) {
+	define('OUT', 1);
+}
+
+if (!function_exists('cacti_escapeshellarg')) {
+	function cacti_escapeshellarg($string, $quote = true) {
+		return escapeshellarg($string);
+	}
+}
+
+if (!class_exists('WeatherMapDataSource')) {
+	class WeatherMapDataSource {
+		public $local_data_id;
+
+		public $down_cache = [];
+
+		public function Init(&$map) {
+			return true;
+		}
+
+		public function Recognise($targetstring) {
+			return false;
+		}
+
+		public function ReadData($targetstring, &$map, &$item) {
+			return ([-1, -1, 0]);
+		}
+	}
+}
+
+/**
+ * Build the $item stand-in a datasource ReadData() expects.
+ *
+ * @param  string   $name value for the name property the datasources read
+ * @return stdClass
+ */
+function wm_test_item($name = 'testitem') {
+	$item       = new stdClass();
+	$item->name = $name;
+
+	return $item;
+}

--- a/tests/Security/RrdOptionsGuardTest.php
+++ b/tests/Security/RrdOptionsGuardTest.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once __DIR__ . '/../Helpers/DataSourceHarness.php';
+require_once dirname(__DIR__, 2) . '/lib/datasources/WeatherMapDataSource_rrd.php';
+
+describe('rrd_options quote and backslash guard', function () {
+	/* The guard previously used the pattern '/["\'\\]/', which PCRE read as an
+	 * unterminated character class.  preg_match() returned false, the else
+	 * branch ran every time, and the check never rejected anything.  These
+	 * cases pin the behaviour the guard is meant to have. */
+	it('rejects a double quote', function () {
+		$ds = new WeatherMapDataSource_rrd();
+
+		expect($ds->wmrrd_options_are_safe('--start "-1h"'))->toBeFalse();
+	});
+
+	it('rejects a single quote', function () {
+		$ds = new WeatherMapDataSource_rrd();
+
+		expect($ds->wmrrd_options_are_safe("--start '-1h'"))->toBeFalse();
+	});
+
+	it('rejects a backslash', function () {
+		$ds = new WeatherMapDataSource_rrd();
+
+		expect($ds->wmrrd_options_are_safe('--start \\-1h'))->toBeFalse();
+	});
+
+	it('accepts plain space separated flags', function () {
+		$ds = new WeatherMapDataSource_rrd();
+
+		expect($ds->wmrrd_options_are_safe('--start -1h --end now'))->toBeTrue();
+	});
+
+	it('accepts an empty value and a null value', function () {
+		$ds = new WeatherMapDataSource_rrd();
+
+		expect($ds->wmrrd_options_are_safe(''))->toBeTrue();
+		expect($ds->wmrrd_options_are_safe(null))->toBeTrue();
+	});
+
+	it('is not fooled by a quote at the very end of the string', function () {
+		$ds = new WeatherMapDataSource_rrd();
+
+		expect($ds->wmrrd_options_are_safe('--start -1h"'))->toBeFalse();
+	});
+});

--- a/tests/Unit/DataSourceReadDataTest.php
+++ b/tests/Unit/DataSourceReadDataTest.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once __DIR__ . '/../Helpers/DataSourceHarness.php';
+require_once dirname(__DIR__, 2) . '/lib/datasources/WeatherMapDataSource_cacti.php';
+require_once dirname(__DIR__, 2) . '/lib/datasources/WeatherMapDataSource_wmdata.php';
+
+describe('datasource ReadData runs without a fatal error', function () {
+	it('cacti datasource returns a three element array', function () {
+		$ds   = new WeatherMapDataSource_cacti();
+		$map  = new stdClass();
+		$item = wm_test_item();
+
+		$result = $ds->ReadData('cacti:123', $map, $item);
+
+		expect($result)->toBeArray()->toHaveCount(3);
+	});
+
+	it('wmdata datasource reads a value out of its tab separated file', function () {
+		$datafile = tempnam(sys_get_temp_dir(), 'wmdata');
+		file_put_contents($datafile, "othername\t1\t2\nmyname\t100\t200\n");
+
+		$ds   = new WeatherMapDataSource_wmdata();
+		$map  = new stdClass();
+		$item = wm_test_item();
+
+		$result = $ds->ReadData('wmdata:' . $datafile . ':myname', $map, $item);
+
+		unlink($datafile);
+
+		expect($result)->toBeArray()->toHaveCount(3);
+		expect($result[IN])->toEqual('100');
+		expect($result[OUT])->toEqual('200');
+		expect($result[2])->toBeGreaterThan(0);
+	});
+
+	it('wmdata datasource returns nulls when the named value is absent', function () {
+		$datafile = tempnam(sys_get_temp_dir(), 'wmdata');
+		file_put_contents($datafile, "othername\t1\t2\n");
+
+		$ds   = new WeatherMapDataSource_wmdata();
+		$map  = new stdClass();
+		$item = wm_test_item();
+
+		$result = $ds->ReadData('wmdata:' . $datafile . ':missing', $map, $item);
+
+		unlink($datafile);
+
+		expect($result[IN])->toBeNull();
+		expect($result[OUT])->toBeNull();
+	});
+
+	it('wmdata datasource survives a target naming a file that is not there', function () {
+		$ds   = new WeatherMapDataSource_wmdata();
+		$map  = new stdClass();
+		$item = wm_test_item();
+
+		$result = $ds->ReadData('wmdata:/nonexistent/path/file.txt:name', $map, $item);
+
+		expect($result)->toBeArray()->toHaveCount(3);
+		expect($result[IN])->toBeNull();
+	});
+
+	it('wmdata Recognise accepts a wmdata target and rejects others', function () {
+		$ds = new WeatherMapDataSource_wmdata();
+
+		expect($ds->Recognise('wmdata:/tmp/file.txt:name'))->toBeTrue();
+		expect($ds->Recognise('cacti:123'))->toBeFalse();
+	});
+});


### PR DESCRIPTION
Three defects that stop a datasource dead, all reachable from a normal poller
run. Each is covered by a test that fails without the change.

- `string_or_null()` is called in the cacti and wmdata datasources and defined
  nowhere in the plugin or in Cacti, so every `cacti:` target read ended in
  `Error: Call to undefined function`. The surrounding datasources already use
  an inline null check; these now match.
- the `wmdata:` target regex had no closing delimiter. `preg_match()` returned
  false, `$datafile` stayed unset, and `file_exists()` raised a TypeError under
  that file's `strict_types`. The same method also opened `$targetstring`
  rather than `$datafile` and never closed the handle.
- the rrd_options guard used `'/["\'\\]/'`, which PCRE reads as an unterminated
  character class, so `preg_match()` returned false and the check never
  rejected anything. It is now one `strpbrk()` predicate shared by both call
  sites. Options were passed through `cacti_escapeshellarg()` either way, so
  nothing was injectable through the dead guard.

Verification: 130 passed on 8.1, 8.3 and 8.4.

Second of seven; needs #1.
